### PR TITLE
Only run CI e2e tests on approved PRs

### DIFF
--- a/.github/workflows/call-core-tests.yml
+++ b/.github/workflows/call-core-tests.yml
@@ -1,0 +1,62 @@
+name: Lexical Core Tests
+
+on:
+  workflow_call:
+
+jobs:
+  integrity:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.11.0]
+    env:
+      CI: true
+      GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - run: npm run ci-check
+      - run: npm run build
+      - run: npm run build-www
+
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.18.0]
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - run: npm run test-unit
+
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.18.0]
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - run: npm run test-integration

--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -1,90 +1,17 @@
-name: Lexical Tests
+name: Lexical e2e tests
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'packages/lexical-website/**'
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'packages/lexical-website/**'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
-  integrity:
-    if: github.repository_owner == 'facebook'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20.11.0]
-    env:
-      CI: true
-      GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - run: npm run ci-check
-      - run: npm run build
-      - run: npm run build-www
-
-  unit:
-    if: github.repository_owner == 'facebook'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-    env:
-      CI: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - run: npm run test-unit
-
-  integration:
-    if: github.repository_owner == 'facebook'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-    env:
-      CI: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - run: npm run test-integration
-
-  e2e-mac:
-    if: github.repository_owner == 'facebook'
+  mac:
     strategy:
       matrix:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox', 'webkit']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'macos-latest'
       node-version: ${{ matrix.node-version }}
@@ -92,15 +19,14 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
 
-  e2e-linux:
-    if: github.repository_owner == 'facebook'
+  linux:
     strategy:
       matrix:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'ubuntu-latest'
       node-version: ${{ matrix.node-version }}
@@ -108,15 +34,14 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
 
-  e2e-windows:
-    if: github.repository_owner == 'facebook'
+  windows:
     strategy:
       matrix:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'windows-latest'
       node-version: ${{ matrix.node-version }}
@@ -124,13 +49,12 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
 
-  e2e-collab-mac:
-    if: github.repository_owner == 'facebook'
+  collab-mac:
     strategy:
       matrix:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox', 'webkit']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'macos-latest'
       node-version: ${{ matrix.node-version }}
@@ -138,13 +62,12 @@ jobs:
       editor-mode: 'rich-text-with-collab'
       events-mode: 'modern-events'
 
-  e2e-collab-linux:
-    if: github.repository_owner == 'facebook'
+  collab-linux:
     strategy:
       matrix:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'ubuntu-latest'
       node-version: ${{ matrix.node-version }}
@@ -152,13 +75,12 @@ jobs:
       editor-mode: 'rich-text-with-collab'
       events-mode: 'modern-events'
 
-  e2e-collab-windows:
-    if: github.repository_owner == 'facebook'
+  collab-windows:
     strategy:
       matrix:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'windows-latest'
       node-version: ${{ matrix.node-version }}
@@ -166,8 +88,7 @@ jobs:
       editor-mode: 'rich-text-with-collab'
       events-mode: 'modern-events'
 
-  e2e-prod:
-    if: github.repository_owner == 'facebook'
+  prod:
     strategy:
       matrix:
         os: ['macos-latest']
@@ -175,7 +96,7 @@ jobs:
         browser: ['chromium']
         editor-mode: ['rich-text']
         events-mode: ['modern-events']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       prod: true
       os: ${{ matrix.os }}
@@ -184,8 +105,7 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
 
-  e2e-collab-prod:
-    if: github.repository_owner == 'facebook'
+  collab-prod:
     strategy:
       matrix:
         os: ['macos-latest']
@@ -193,7 +113,7 @@ jobs:
         browser: ['chromium']
         editor-mode: ['rich-text-with-collab']
         events-mode: ['modern-events']
-    uses: ./.github/workflows/e2e-test.yml
+    uses: ./.github/workflows/call-e2e-test.yml
     with:
       prod: true
       os: ${{ matrix.os }}

--- a/.github/workflows/call-e2e-canary-tests.yml
+++ b/.github/workflows/call-e2e-canary-tests.yml
@@ -1,0 +1,21 @@
+name: Lexical e2e canary test
+
+on:
+  workflow_call:
+
+jobs:
+  canary:
+    strategy:
+      matrix:
+        os: ['macos-latest']
+        node-version: [18.18.0]
+        browser: ['chromium']
+        editor-mode: ['rich-text']
+        events-mode: ['modern-events']
+    uses: ./.github/workflows/call-e2e-test.yml
+    with:
+      os: ${{ matrix.os }}
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}

--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -1,4 +1,4 @@
-name: Lexical e2e Tests
+name: Lexical e2e test runner
 
 on:
   workflow_call:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,10 +1,10 @@
-name: 'size'
+name: 'Bundles'
 on:
   pull_request:
     branches:
       - main
 jobs:
-  size:
+  size-limit:
     runs-on: ubuntu-latest
     env:
       CI_JOB_NUMBER: 1

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -1,0 +1,16 @@
+name: Lexical Tests (Extended)
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    paths-ignore:
+      - 'packages/lexical-website/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-tests:
+    if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'approved')
+    uses: ./.github/workflows/call-e2e-all-tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Lexical Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'packages/lexical-website/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'packages/lexical-website/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core-tests:
+    uses: ./.github/workflows/call-core-tests.yml
+
+  e2e-tests:
+    if: github.repository_owner == 'facebook'
+    uses: ./.github/workflows/call-e2e-canary-tests.yml

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-  '*.(js|mjs|jsx|css|html|d.ts|ts|tsx)': 'prettier --write',
+  '*.(js|mjs|jsx|css|html|d.ts|ts|tsx|yml)': 'prettier --write',
   '*.(js|mjs|jsx|ts|tsx)': ['eslint --fix'],
 };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,19 @@ possible.
 We actively welcome your pull requests.
 
 1. Fork the repo and create your branch from `main`.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
-6. If you haven't already, complete the Contributor License Agreement ("CLA").
+2. Run `npm install` to install dependencies.
+3. If you've added code that should be tested, add tests.
+4. If you've changed APIs, update the documentation.
+5. Ensure the test suite passes.
+6. Make sure your code lints.
+7. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+Note that the local server needs to be running in order to run the e2e tests.
+
+- `npm run start`
+- `npm run test-e2e-chromium` (to run only chromium e2e tests)
+
+`npm run start` will start both the dev server and collab server. If you don't need collab, use `npm run dev` to start just the dev server.
 
 ## Contributor License Agreement ("CLA")
 

--- a/README.md
+++ b/README.md
@@ -334,18 +334,7 @@ editor.registerUpdateListener(({editorState}) => {
 
 ## Contributing to Lexical
 
-1. Clone this repository
-
-2. Install dependencies
-
-   - `npm install`
-
-3. Start local server and run tests
-   - `npm run start`
-   - `npm run test-e2e-chromium` to run only chromium e2e tests
-     - The server needs to be running for the e2e tests
-
-`npm run start` will start both the dev server and collab server. If you don't need collab, use `npm run dev` to start just the dev server.
+Please read the [CONTRIBUTING.md](https://github.com/facebook/lexical/blob/main/CONTRIBUTING.md).
 
 ### Optional but recommended, use VSCode for development
 


### PR DESCRIPTION
Avoid running the entire suite of (expensive) e2e tests on every PR that is opened or updated. Only run if PR is approved.

Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-when-a-pull-request-is-approved

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

**Closes:** #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*